### PR TITLE
Remove duplicate header fields in project-proposal.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/project-proposal.yml
@@ -1,9 +1,3 @@
-name: Project Proposal
-description: Apply for your project to become an official Project (Growth or Impact) under the Agentic AI Foundation
-title: "[Project Proposal]: "
-labels:
-  - new
-
 name: Project Proposal Application
 description: Apply for your project to become an official Project under the Agentic AI Foundation.
 title: "[Project Proposal] <ADD Project Name> "


### PR DESCRIPTION
The file had two sets of top-level fields (name, description, title, labels). YAML parsers use the last value when keys are duplicated, so the first block had no effect. Removed the first block and kept the second one, which includes the assignees field and the correct title format.