### PR TITLE
Make Roadmap and Security fields optional in proposal form

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/project-proposal.yml
@@ -134,16 +134,16 @@ body:
   - type: textarea
     attributes:
       label: Roadmap
-      description: "Link to or provide a 12-month public roadmap for the project."
+      description: "Link to or provide a 12-month public roadmap for the project, if available."
     validations:
-      required: true
+      required: false
 
   - type: textarea
     attributes:
       label: Security
-      description: "Has the project received a Silver badge or better from OpenSSF Best Practices? If so, please link the badge or status."
+      description: "If the project has an OpenSSF Best Practices badge, link it here. Otherwise, describe the project's current security posture."
     validations:
-      required: true
+      required: false
 
   - type: input
     attributes:


### PR DESCRIPTION
The project lifecycle policy has two lists: required items and optional items.

Roadmap and OpenSSF badge both appear under the optional list in the policy:

> Projects can optionally provide the following:
> - a published roadmap
> - openSSF best practices badge

The proposal form had both marked as required, which blocks applicants who do not have them yet, even though the policy does not require them.

This change aligns the form with the policy. If the intent was to require these in the form regardless of what the policy says, happy to close this.