### PR TITLE
fix: correct typos in lifecycle policy and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/project-proposal.yml
@@ -218,7 +218,7 @@ body:
   - type: textarea
     attributes:
       label: Application contact name(s) and email(s)
-      description: Provide the name(s) and email address(es) of individuals who should be contacted regarding this application. If more than one nam and email is provided, please comma separate them.
+      description: Provide the name(s) and email address(es) of individuals who should be contacted regarding this application. If more than one name and email is provided, please comma separate them.
       placeholder: Comma-separate multiple emails here
     validations:
       required: true

--- a/governance/project-lifecycle-policy.md
+++ b/governance/project-lifecycle-policy.md
@@ -151,12 +151,12 @@ Emeritus projects are projects which the TC or maintainers feel have reached end
 
 ### Examples
 
-1. Projects that are are no longer maintained.  
+1. Projects that are no longer maintained.  
 2. Projects that do not plan to release major versions in the future.
 
 ### Expectations
 
-Projects in this stage are have little to no activity. Their maintainers may infrequently monitor their repositories and may only push updates to address security issues, if at all. Emeritus projects should clearly state their status in their repo’s README.md and what users or contributors can expect regarding response times or support. If there is an alternative project the maintainers recommend, it should be listed as well. The foundation will continue to hold the IP and any trademarks and domains, but the project does not draw on foundation resources. 
+Projects in this stage have little to no activity. Their maintainers may infrequently monitor their repositories and may only push updates to address security issues, if at all. Emeritus projects should clearly state their status in their repo’s README.md and what users or contributors can expect regarding response times or support. If there is an alternative project the maintainers recommend, it should be listed as well. The foundation will continue to hold the IP and any trademarks and domains, but the project does not draw on foundation resources. 
 
 ### Acceptance Criteria
 


### PR DESCRIPTION
Three typos fixed in two files.

In governance/project-lifecycle-policy.md (Emeritus Stage section):
- "Projects that are are no longer maintained" had a duplicate word
- "Projects in this stage are have little to no activity" had two extra words

In .github/ISSUE_TEMPLATE/project-proposal.yml:
- "If more than one nam and email" was missing the letter e in name